### PR TITLE
Fix breakr_activate on missing env var

### DIFF
--- a/src/breakr.c
+++ b/src/breakr.c
@@ -22,7 +22,7 @@ void breakr_activate()
 	const char *str = getenv("BREAKR_MODE");
 	if (str == NULL)
 	{
-		active == LOG;
+		active = LOG;
 	}
 	else
 	{


### PR DESCRIPTION
There is a small typo in `|breakr_activate|`. If the `BREAKR_MODE` environment variable is not set, `activate` will not be set to `LOG`, as was clearly intended, but will instead be compared for equality against `LOG`.

This pull request fixes that typo and does nothing more.